### PR TITLE
Update number pattern with underscore separators

### DIFF
--- a/syntax/kotlin.vim
+++ b/syntax/kotlin.vim
@@ -49,9 +49,9 @@ syn match ktLabel "\v\w+\@"
 syn match ktSimpleInterpolation "\v\$\h\w*" contained
 syn region ktComplexInterpolation matchgroup=ktComplexInterpolationBrace start="\v\$\{" end="\v\}" contains=ALLBUT,ktSimpleInterpolation
 
-syn match ktNumber "\v<\d+(_\d+)*[LFf]?"
-syn match ktNumber "\v<0[Xx]\x+(_\x+)*L?"
-syn match ktNumber "\v<0[Bb][01]+(_[01]+)*L?"
+syn match ktNumber "\v<\d+[_[:digit:]]*[LFf]?"
+syn match ktNumber "\v<0[Xx]\x+[_[:xdigit:]]*L?"
+syn match ktNumber "\v<0[Bb][01]+[_01]*L?"
 syn match ktFloat "\v<\d*(\d[eE][-+]?\d+|\.\d+([eE][-+]?\d+)?)[Ff]?"
 
 syn match ktEscapedName "\v`.*`"

--- a/syntax/kotlin.vim
+++ b/syntax/kotlin.vim
@@ -49,9 +49,9 @@ syn match ktLabel "\v\w+\@"
 syn match ktSimpleInterpolation "\v\$\h\w*" contained
 syn region ktComplexInterpolation matchgroup=ktComplexInterpolationBrace start="\v\$\{" end="\v\}" contains=ALLBUT,ktSimpleInterpolation
 
-syn match ktNumber "\v<\d+[LFf]?"
-syn match ktNumber "\v<0[Xx]\x+L?"
-syn match ktNumber "\v<0[Bb]\d+L?"
+syn match ktNumber "\v<\d+(_\d+)*[LFf]?"
+syn match ktNumber "\v<0[Xx]\x+(_\x+)*L?"
+syn match ktNumber "\v<0[Bb][01]+(_[01]+)*L?"
 syn match ktFloat "\v<\d*(\d[eE][-+]?\d+|\.\d+([eE][-+]?\d+)?)[Ff]?"
 
 syn match ktEscapedName "\v`.*`"


### PR DESCRIPTION
As far as I know, the number constants like '1_000_000', '0xFF_EC_DE_5E' and '0b11010010_01101001_10010100_10010010' are also valid, so I updated these three patterns. By the way, the pattern for binary numbers should accept 0 and 1 only, I corrected it as well.