### PR TITLE
Add ftplugin to set comment syntax

### DIFF
--- a/ftplugin/kotlin.vim
+++ b/ftplugin/kotlin.vim
@@ -1,0 +1,2 @@
+setlocal comments=://
+setlocal commentstring=//\ %s


### PR DESCRIPTION
The plugin as it stands does not set the comment syntax, which means various Vim features acting on comments don't work properly.

This adds settings for comment syntax when editing Kotlin files.