### PR TITLE
Do not double-indent argument lists

### DIFF
--- a/indent/kotlin.vim
+++ b/indent/kotlin.vim
@@ -43,11 +43,11 @@ function! GetKotlinIndent()
     let cur_close_paren = cur =~ '^\s*).*$'
 
     if prev_open_paren && !cur_close_paren
-        return prev_indent + 2 * &shiftwidth
+        return prev_indent + &shiftwidth
     endif
 
     if cur_close_paren && !prev_open_paren
-        return prev_indent - 2 * &shiftwidth
+        return prev_indent - &shiftwidth
     endif
 
 


### PR DESCRIPTION
As described in [Kotlin coding conventions][1] parameters in class
headers, functions and method calls must be indented with a single
indent. Intellij IDEA is also [migrating to this style][2].

This change makes kotlin-vim adopt the official indentation format of
Kotlin.

[1]: https://kotlinlang.org/docs/reference/coding-conventions.html
[2]: https://kotlinlang.org/docs/reference/code-style-migration-guide.html