### PR TITLE
Enable `gf` on import statements

### DIFF
--- a/ftplugin/kotlin.vim
+++ b/ftplugin/kotlin.vim
@@ -3,3 +3,6 @@ let b:did_ftplugin = 1
 
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
+
+setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+setlocal suffixesadd=.kt


### PR DESCRIPTION
The `gf` command opens files under the cursor. This change configures
the kotlin filetype to enable this command on import statements by
replacing dots and appending the file extension.

The functionality is copied from ftplugin/java.vim as distributed in vim
source code.