### PR TITLE
Add three-piece comments declaration

### DIFF
--- a/ftplugin/kotlin.vim
+++ b/ftplugin/kotlin.vim
@@ -1,5 +1,5 @@
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
 
-setlocal comments=://
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s


### PR DESCRIPTION
This allows us to have C-style comments in kotlin, a la:
```
/**
 * Start of comment
 *
 * More comment
 */
```
and have vim autoindent them (according to your formatoptions setting,
that is).  I copied the setting from the builtin ftplugin for
JavaScript, since they have equivalent comment syntax.