### PR TITLE
Add missing basic kotlin types

### DIFF
--- a/syntax/kotlin.vim
+++ b/syntax/kotlin.vim
@@ -18,7 +18,7 @@ syn keyword ktException try catch finally throw
 
 syn keyword ktInclude import package
 
-syn keyword ktType Any Boolean Byte Char Double Float Int Long Nothing Short Unit
+syn keyword ktType Any Array Boolean Byte Char Double Float Int Long Nothing Short String UByte UInt ULong UShort Unit
 syn keyword ktModifier annotation companion enum inner internal private protected public abstract final open override sealed vararg dynamic expect actual
 syn keyword ktStructure class object interface typealias fun val var constructor init
 


### PR DESCRIPTION
Reading the [basic types][1] documentation we can see that the following
are already added to `ktType`:

* Numbers
* Charaters
* Booleans

But the following are missing:

* Arrays
* Unsigned integers
* Strings

This change adds the missing basic types to `ktType` so that they can be
properly highlighter.

Fixes udalov/kotlin-vim#12.

[1]: https://kotlinlang.org/docs/reference/basic-types.html