### PR TITLE
Highlight function, class, interface, type definitions

### DIFF
--- a/syntax/kotlin.vim
+++ b/syntax/kotlin.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: Kotlin
 " Maintainer: Alexander Udalov
-" Latest Revision: 26 May 2019
+" Latest Revision: 1 July 2020
 
 if exists('b:current_syntax')
     finish
@@ -19,6 +19,8 @@ syn keyword ktInclude import package
 syn keyword ktType Any Boolean Byte Char Double Float Int Long Nothing Short Unit
 syn keyword ktModifier annotation companion enum inner internal private protected public abstract final open override sealed vararg dynamic expect actual
 syn keyword ktStructure class object interface typealias fun val var constructor init
+
+syn keyword ktKeyword class object interface fun typealias nextgroup=ktItemName skipwhite skipempty
 
 syn keyword ktReservedKeyword typeof
 
@@ -39,6 +41,7 @@ syn match ktDocTag "\v\@(author|constructor|receiver|return|since|suppress)>" co
 syn match ktDocTag "\v\@(exception|param|property|throws|see|sample)>\s*\S+" contains=ktDocTagParam contained
 syn match ktDocTagParam "\v(\s|\[)\S+" contained
 syn match ktComment "/\*\*/"
+syn match ktItemName "\v([a-zA-Z_][a-zA-Z0-9_]*|`[^`]+`)" contained
 
 syn match ktSpecialCharError "\v\\." contained
 syn match ktSpecialChar "\v\\([tbnr'"$\\]|u\x{4})" contained
@@ -79,6 +82,7 @@ hi def link ktType Type
 hi def link ktModifier StorageClass
 hi def link ktStructure Structure
 hi def link ktTypedef Typedef
+hi def link ktItemName Function
 
 hi def link ktBoolean Boolean
 hi def link ktConstant Constant


### PR DESCRIPTION
Pictures say more than words, so [here is one](https://i.kageru.moe/kBUBnI.png).

Function/constructor calls aren’t highlighted yet.
I would like to add that as well, but that feels like a separate issue to me, and I don’t know if you even want it.