### PR TITLE
Raw strings don't do backslash escaping.

### DIFF
--- a/syntax/kotlin.vim
+++ b/syntax/kotlin.vim
@@ -69,7 +69,7 @@ syn match ktComment "/\*\*/"
 syn match ktSpecialCharError "\v\\." contained
 syn match ktSpecialChar "\v\\([tbnr'"$\\]|u\x{4})" contained
 syn region ktString start='"' skip='\\"' end='"' contains=ktSimpleInterpolation,ktComplexInterpolation,ktSpecialChar,ktSpecialCharError
-syn region ktString start='"""' end='""""*' contains=ktSimpleInterpolation,ktComplexInterpolation,ktSpecialChar,ktSpecialCharError
+syn region ktString start='"""' end='""""*'
 syn match ktCharacter "\v'[^']*'" contains=ktSpecialChar,ktSpecialCharError
 syn match ktCharacter "\v'\\''" contains=ktSpecialChar
 syn match ktCharacter "\v'[^\\]'"

--- a/syntax/kotlin.vim
+++ b/syntax/kotlin.vim
@@ -69,7 +69,7 @@ syn match ktComment "/\*\*/"
 syn match ktSpecialCharError "\v\\." contained
 syn match ktSpecialChar "\v\\([tbnr'"$\\]|u\x{4})" contained
 syn region ktString start='"' skip='\\"' end='"' contains=ktSimpleInterpolation,ktComplexInterpolation,ktSpecialChar,ktSpecialCharError
-syn region ktString start='"""' end='""""*'
+syn region ktString start='"""' end='""""*' contains=ktSimpleInterpolation,ktComplexInterpolation
 syn match ktCharacter "\v'[^']*'" contains=ktSpecialChar,ktSpecialCharError
 syn match ktCharacter "\v'\\''" contains=ktSpecialChar
 syn match ktCharacter "\v'[^\\]'"


### PR DESCRIPTION
Regarding issue #36, raw strings do not have any processing, escaping, nor interpolation in Kotlin.