### PR TITLE
spell: Enable spell checking in strings

### DIFF
--- a/syntax/kotlin.vim
+++ b/syntax/kotlin.vim
@@ -74,8 +74,8 @@ syn match ktComment "/\*\*/"
 
 syn match ktSpecialCharError "\v\\." contained
 syn match ktSpecialChar "\v\\([tbnr'"$\\]|u\x{4})" contained
-syn region ktString start='"' skip='\\"' end='"' contains=ktSimpleInterpolation,ktComplexInterpolation,ktSpecialChar,ktSpecialCharError
-syn region ktString start='"""' end='""""*' contains=ktSimpleInterpolation,ktComplexInterpolation
+syn region ktString start='"' skip='\\"' end='"' contains=ktSimpleInterpolation,ktComplexInterpolation,ktSpecialChar,ktSpecialCharError,@Spell
+syn region ktString start='"""' end='""""*' contains=ktSimpleInterpolation,ktComplexInterpolation,@Spell
 syn match ktCharacter "\v'[^']*'" contains=ktSpecialChar,ktSpecialCharError
 syn match ktCharacter "\v'\\''" contains=ktSpecialChar
 syn match ktCharacter "\v'[^\\]'"


### PR DESCRIPTION
This PR enables spell checking within strings.

Most of the other syntax specifications enable this by default (even built in ones):
- https://github.com/neovim/neovim/blob/c1fbc2ddf15b2f44b615f90b2511349ab974cb83/runtime/syntax/c.vim#L60
- https://github.com/neovim/neovim/blob/c1fbc2ddf15b2f44b615f90b2511349ab974cb83/runtime/syntax/java.vim#L182
- https://github.com/neovim/neovim/blob/c1fbc2ddf15b2f44b615f90b2511349ab974cb83/runtime/syntax/python.vim#L139
- https://github.com/vim/vim/blob/master/runtime/syntax/python.vim (even the original vim)